### PR TITLE
feat: add new `toHaveScreenshot` assertion

### DIFF
--- a/lib/rules/missing-playwright-await.js
+++ b/lib/rules/missing-playwright-await.js
@@ -59,6 +59,7 @@ const playwrightTestMatchers = [
   "toHaveId",
   "toHaveJSProperty",
   "toBeOK",
+  "toHaveScreenshot",
   "toHaveText",
   "toHaveTitle",
   "toHaveURL",


### PR DESCRIPTION
adds the new `toHaveScreenshot` assertion introduced in [Playwright 1.22](https://playwright.dev/docs/release-notes#version-122) to the `missing-playwright-await` rule